### PR TITLE
SAP-16270: Add obsolete warning to HPO legend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            npm install
+            npm ci
             bower install
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}

--- a/css/editor.css
+++ b/css/editor.css
@@ -210,7 +210,6 @@ body {
 #panogram .legend-box .disorder-list li.disorder {
   padding-bottom: 0.35em;
   margin-left: 1.4em;
-  /*line-height: 100%;*/
 }
 #panogram .legend-box .disorder-list li.disorder.drop-phenotype {
   margin-left: 0;

--- a/css/editor.css
+++ b/css/editor.css
@@ -249,7 +249,8 @@ body {
   content: "\f071";
   color: #ff8a00;
   position: absolute;
-  left: -15px;
+  left: -18px;
+  top: 3px;
 }
 
 #panogram .disorder .tooltiptext {

--- a/css/editor.css
+++ b/css/editor.css
@@ -237,6 +237,30 @@ body {
   font-style: italic;
   color: #777;
 }
+
+#panogram .disorder.obsolete {
+  position: relative;
+  display: inline-block;
+}
+
+#panogram .disorder.obsolete .tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: #000000;
+  color: white;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
+  position: absolute;
+  z-index: 1;
+  top: -5px;
+  left: 105%;
+}
+
+#panogram .disorder.obsolete:hover .tooltiptext{
+  visibility: visible;
+}
+
 /* ===========================================
  * NODE MENU
  */

--- a/css/editor.css
+++ b/css/editor.css
@@ -210,7 +210,7 @@ body {
 #panogram .legend-box .disorder-list li.disorder {
   padding-bottom: 0.35em;
   margin-left: 1.4em;
-  line-height: 100%;
+  /*line-height: 100%;*/
 }
 #panogram .legend-box .disorder-list li.disorder.drop-phenotype {
   margin-left: 0;
@@ -238,6 +238,7 @@ body {
   color: #777;
 }
 
+/* Styles for obsolete HPO Terms and tooltips */
 #panogram .disorder.obsolete {
   position: relative;
   display: inline-block;
@@ -247,7 +248,7 @@ body {
   font-family: FontAwesome;
   font-size: 12px;
   content: "\f071";
-  color: orange;
+  color: #ff8a00;
   position: absolute;
   left: -15px;
 }

--- a/css/editor.css
+++ b/css/editor.css
@@ -243,18 +243,30 @@ body {
   display: inline-block;
 }
 
-#panogram .disorder.obsolete .tooltiptext {
+#panogram .disorder.obsolete::before {
+  font-family: FontAwesome;
+  font-size: 12px;
+  content: "\f071";
+  color: orange;
+  position: absolute;
+  left: -15px;
+}
+
+#panogram .disorder .tooltiptext {
   visibility: hidden;
-  width: 120px;
+  position: absolute;
+}
+
+#panogram .disorder.obsolete .tooltiptext {
+  width: 200px;
   background-color: #000000;
   color: white;
   text-align: center;
   padding: 5px 0;
-  border-radius: 6px;
-  position: absolute;
+  border-radius: 3px;
   z-index: 1;
-  top: -5px;
-  left: 105%;
+  top: 20px;
+  left: 20px;
 }
 
 #panogram .disorder.obsolete:hover .tooltiptext{

--- a/main.bundle.js
+++ b/main.bundle.js
@@ -27707,12 +27707,15 @@ var Legend = exports.Legend = Class.create({
    */
   _generateElement: function _generateElement(id, name, isObsolete) {
     var color = this.getObjectColor(id);
-    var obsoleteClass = isObsolete ? 'obsolete ' : '';
-    var item = new Element('li', { 'class': 'disorder ' + obsoleteClass + 'drop-' + this._getPrefix(), 'id': this._getPrefix() + '-' + id }).update(new Element('span', { 'class': 'disorder-name' }).update(name));
+    var obsoleteClass = isObsolete ? 'obsolete' : '';
+    var item = new Element('li', { 'class': 'disorder ' + obsoleteClass + ' drop-' + this._getPrefix(), 'id': this._getPrefix() + '-' + id }).update(new Element('span', { 'class': 'disorder-name' }).update(name));
     var bubble = new Element('span', { 'class': 'disorder-color' });
     var tooltiptext = new Element('span', { class: 'tooltiptext' }).insert('This HPO term is obsolete. See the HPO terms tab for details.');
     bubble.style.backgroundColor = color;
-    item.insert({ 'top': bubble }).insert(tooltiptext);
+    item.insert({ 'top': bubble });
+    if (isObsolete) {
+      item.insert(tooltiptext);
+    }
     var countLabel = new Element('span', { 'class': 'disorder-cases' });
     var countLabelContainer = new Element('span', { 'class': 'disorder-cases-container' }).insert('(').insert(countLabel).insert(')');
     item.insert(' ').insert(countLabelContainer);

--- a/main.bundle.js
+++ b/main.bundle.js
@@ -28615,7 +28615,6 @@ var Person = exports.Person = Class.create(_abstractPerson.AbstractPerson, {
       this.removeHPO(this.getHPO()[i]);
     }
     for (i = 0; i < hpos.length; i++) {
-      console.log("SET HPO: " + hpos[i]);
       this.addHPO(hpos[i]);
     }
   },

--- a/main.bundle.js
+++ b/main.bundle.js
@@ -16700,11 +16700,12 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  *
  * @param hpoID the id number for the HPO term, taken from the HPO database
  * @param name a string representing the name of the term e.g. "Abnormality of the eye"
+ * @param obsolete a boolean representing whether the HPO term is obsolete
  */
 
 var HPOTerm = exports.HPOTerm = Class.create({
 
-  initialize: function initialize(hpoID, name, callWhenReady) {
+  initialize: function initialize(hpoID, name, isObsolete, callWhenReady) {
     // user-defined terms
     if (name == null && !HPOTerm.isValidID(HPOTerm.desanitizeID(hpoID))) {
       name = HPOTerm.desanitizeID(hpoID);
@@ -16712,7 +16713,7 @@ var HPOTerm = exports.HPOTerm = Class.create({
 
     this._hpoID = HPOTerm.sanitizeID(hpoID);
     this._name = name ? name : 'loading...';
-    this._obsolete = true;
+    this._obsolete = isObsolete;
 
     if (!name && callWhenReady) this.load(callWhenReady);
   },
@@ -16731,6 +16732,9 @@ var HPOTerm = exports.HPOTerm = Class.create({
     return this._name;
   },
 
+  /*
+   * Returns whether the term is obsolete 
+   */
   getObsolete: function getObsolete() {
     return this._obsolete;
   },
@@ -16753,7 +16757,6 @@ var HPOTerm = exports.HPOTerm = Class.create({
       //console.log(stringifyObject(parsed));
       console.log('LOADED HPO TERM: id = ' + HPOTerm.desanitizeID(this._hpoID) + ', name = ' + parsed.rows[0].name);
       this._name = parsed.rows[0].name;
-      this._obsolete = true;
     } catch (err) {
       console.log('[LOAD HPO TERM] Error: ');
       console.trace(err);
@@ -27704,11 +27707,12 @@ var Legend = exports.Legend = Class.create({
    */
   _generateElement: function _generateElement(id, name, isObsolete) {
     var color = this.getObjectColor(id);
-    var obsoleteClass = isObsolete ? "obsolete " : "";
+    var obsoleteClass = isObsolete ? 'obsolete ' : '';
     var item = new Element('li', { 'class': 'disorder ' + obsoleteClass + 'drop-' + this._getPrefix(), 'id': this._getPrefix() + '-' + id }).update(new Element('span', { 'class': 'disorder-name' }).update(name));
     var bubble = new Element('span', { 'class': 'disorder-color' });
+    var tooltiptext = new Element('span', { class: 'tooltiptext' }).insert('This HPO term is obsolete. See the HPO terms tab for details.');
     bubble.style.backgroundColor = color;
-    item.insert({ 'top': bubble });
+    item.insert({ 'top': bubble }).insert(tooltiptext);
     var countLabel = new Element('span', { 'class': 'disorder-cases' });
     var countLabelContainer = new Element('span', { 'class': 'disorder-cases-container' }).insert('(').insert(countLabel).insert(')');
     item.insert(' ').insert(countLabelContainer);
@@ -28564,12 +28568,18 @@ var Person = exports.Person = Class.create(_abstractPerson.AbstractPerson, {
    * Adds HPO term to the list of this node's phenotypes and updates the Legend.
    *
    * @method addHPO
-   * @param {HPOTerm} hpo HPOTerm object or a free-text name string
+   * @param {HPOTerm} hpo HPOTerm object or a free-text name string or an object with name and isObsolete props
    */
   addHPO: function addHPO(hpo) {
+    // Support free-text string argument
     if ((typeof hpo === 'undefined' ? 'undefined' : _typeof(hpo)) != 'object') {
       hpo = editor.getHPOLegend().getTerm(hpo);
     }
+    // Support object with name and isObsolete properties
+    if (hpo && hpo.name) {
+      hpo = editor.getHPOLegend().getTerm(hpo.name, hpo.isObsolete);
+    }
+
     if (!this.hasHPO(hpo.getID())) {
       editor.getHPOLegend().addCase(hpo.getID(), hpo.getName(), this.getID(), hpo.getObsolete());
       this.getHPO().push(hpo.getID());
@@ -28597,7 +28607,7 @@ var Person = exports.Person = Class.create(_abstractPerson.AbstractPerson, {
    * Sets the list of HPO temrs of this person to the given list
    *
    * @method setHPO
-   * @param {Array} hpos List of HPOTerm objects
+   * @param {Array} hpos List of HPO term objects {name: string, isObsolete: bool}
    */
   setHPO: function setHPO(hpos) {
     var i;
@@ -28605,6 +28615,7 @@ var Person = exports.Person = Class.create(_abstractPerson.AbstractPerson, {
       this.removeHPO(this.getHPO()[i]);
     }
     for (i = 0; i < hpos.length; i++) {
+      console.log("SET HPO: " + hpos[i]);
       this.addHPO(hpos[i]);
     }
   },
@@ -41063,12 +41074,14 @@ var HPOLegend = exports.HPOLegend = Class.create(_legend.Legend, {
    * @return {Object}
    */
   getTerm: function getTerm(hpoID) {
+    var isObsolete = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+
     hpoID = _hpoTerm.HPOTerm.sanitizeID(hpoID);
     if (!this._termCache.hasOwnProperty(hpoID)) {
       var whenNameIsLoaded = function whenNameIsLoaded() {
         this._updateTermName(hpoID);
       };
-      this._termCache[hpoID] = new _hpoTerm.HPOTerm(hpoID, null, whenNameIsLoaded.bind(this));
+      this._termCache[hpoID] = new _hpoTerm.HPOTerm(hpoID, null, isObsolete, whenNameIsLoaded.bind(this));
     }
     return this._termCache[hpoID];
   },
@@ -41091,9 +41104,10 @@ var HPOLegend = exports.HPOLegend = Class.create(_legend.Legend, {
    * @param {Number|String} id ID for this term taken from the HPO database
    * @param {String} name The description of the phenotype
    * @param {Number} nodeID ID of the Person who has this phenotype
+   * @param {Boolean} isObsolete Whether the HPO Term is obsolete
    */
   addCase: function addCase($super, id, name, nodeID, isObsolete) {
-    if (!this._termCache.hasOwnProperty(id)) this._termCache[id] = new _hpoTerm.HPOTerm(id, name);
+    if (!this._termCache.hasOwnProperty(id)) this._termCache[id] = new _hpoTerm.HPOTerm(id, name, isObsolete);
 
     $super(id, name, nodeID, isObsolete);
   },

--- a/src/hpoLegend.js
+++ b/src/hpoLegend.js
@@ -55,11 +55,11 @@ export const HPOLegend = Class.create( Legend, {
      * @param {String} name The description of the phenotype
      * @param {Number} nodeID ID of the Person who has this phenotype
      */
-  addCase: function($super, id, name, nodeID) {
+  addCase: function($super, id, name, nodeID, isObsolete) {
     if (!this._termCache.hasOwnProperty(id))
       this._termCache[id] = new HPOTerm(id, name);
 
-    $super(id, name, nodeID);
+    $super(id, name, nodeID, isObsolete);
   },
 
     /**

--- a/src/hpoLegend.js
+++ b/src/hpoLegend.js
@@ -27,11 +27,11 @@ export const HPOLegend = Class.create( Legend, {
      * @method getTerm
      * @return {Object}
      */    
-  getTerm: function(hpoID) {
+  getTerm: function(hpoID, isObsolete = false) {
     hpoID = HPOTerm.sanitizeID(hpoID);
     if (!this._termCache.hasOwnProperty(hpoID)) {
       var whenNameIsLoaded = function() { this._updateTermName(hpoID); };
-      this._termCache[hpoID] = new HPOTerm(hpoID, null, whenNameIsLoaded.bind(this));
+      this._termCache[hpoID] = new HPOTerm(hpoID, null, isObsolete, whenNameIsLoaded.bind(this));
     }
     return this._termCache[hpoID];
   },
@@ -54,10 +54,11 @@ export const HPOLegend = Class.create( Legend, {
      * @param {Number|String} id ID for this term taken from the HPO database
      * @param {String} name The description of the phenotype
      * @param {Number} nodeID ID of the Person who has this phenotype
+     * @param {Boolean} isObsolete Whether the HPO Term is obsolete
      */
   addCase: function($super, id, name, nodeID, isObsolete) {
     if (!this._termCache.hasOwnProperty(id))
-      this._termCache[id] = new HPOTerm(id, name);
+      this._termCache[id] = new HPOTerm(id, name, isObsolete);
 
     $super(id, name, nodeID, isObsolete);
   },

--- a/src/hpoTerm.js
+++ b/src/hpoTerm.js
@@ -18,6 +18,7 @@ export const HPOTerm = Class.create( {
 
     this._hpoID  = HPOTerm.sanitizeID(hpoID);
     this._name   = name ? name : 'loading...';
+    this._obsolete = true;
 
     if (!name && callWhenReady)
       this.load(callWhenReady);
@@ -35,6 +36,10 @@ export const HPOTerm = Class.create( {
      */
   getName: function() {
     return this._name;
+  },
+
+  getObsolete : function() {
+    return this._obsolete;
   },
 
   load: function(callWhenReady) {
@@ -55,6 +60,7 @@ export const HPOTerm = Class.create( {
             //console.log(stringifyObject(parsed));
       console.log('LOADED HPO TERM: id = ' + HPOTerm.desanitizeID(this._hpoID) + ', name = ' + parsed.rows[0].name);
       this._name = parsed.rows[0].name;
+      this._obsolete = true;
     } catch (err) {
       console.log('[LOAD HPO TERM] Error: ');
       console.trace(err);

--- a/src/hpoTerm.js
+++ b/src/hpoTerm.js
@@ -6,11 +6,12 @@ import XRegExp from 'xregexp'
  *
  * @param hpoID the id number for the HPO term, taken from the HPO database
  * @param name a string representing the name of the term e.g. "Abnormality of the eye"
+ * @param obsolete a boolean representing whether the HPO term is obsolete
  */
 
 export const HPOTerm = Class.create( {
 
-  initialize: function(hpoID, name, callWhenReady) {
+  initialize: function(hpoID, name, isObsolete ,callWhenReady) {
         // user-defined terms
     if (name == null && !HPOTerm.isValidID(HPOTerm.desanitizeID(hpoID))) {
       name = HPOTerm.desanitizeID(hpoID);
@@ -18,7 +19,7 @@ export const HPOTerm = Class.create( {
 
     this._hpoID  = HPOTerm.sanitizeID(hpoID);
     this._name   = name ? name : 'loading...';
-    this._obsolete = true;
+    this._obsolete = isObsolete;
 
     if (!name && callWhenReady)
       this.load(callWhenReady);
@@ -38,6 +39,9 @@ export const HPOTerm = Class.create( {
     return this._name;
   },
 
+  /*
+   * Returns whether the term is obsolete 
+   */
   getObsolete : function() {
     return this._obsolete;
   },
@@ -60,7 +64,6 @@ export const HPOTerm = Class.create( {
             //console.log(stringifyObject(parsed));
       console.log('LOADED HPO TERM: id = ' + HPOTerm.desanitizeID(this._hpoID) + ', name = ' + parsed.rows[0].name);
       this._name = parsed.rows[0].name;
-      this._obsolete = true;
     } catch (err) {
       console.log('[LOAD HPO TERM] Error: ');
       console.trace(err);

--- a/src/legend.js
+++ b/src/legend.js
@@ -165,7 +165,7 @@ export const Legend = Class.create( {
     var obsoleteClass = isObsolete ? "obsolete " : "";
     var item = new Element('li', {'class' : 'disorder '+obsoleteClass+'drop-'+this._getPrefix(), 'id' : this._getPrefix() + '-' + id}).update(new Element('span', {'class' : 'disorder-name'}).update(name));
     var bubble = new Element('span', {'class' : 'disorder-color'});
-    var tooltiptext = new Element('span', {'class': 'tooltiptext'}).insert('This HPO term is obsolete');
+    var tooltiptext = new Element('span', {'class': 'tooltiptext'}).insert('This HPO term is obsolete. See the HPO terms tab for details.');
     bubble.style.backgroundColor = color;
     item.insert({'top' : bubble}).insert(tooltiptext);
     var countLabel = new Element('span', {'class' : 'disorder-cases'});

--- a/src/legend.js
+++ b/src/legend.js
@@ -162,10 +162,12 @@ export const Legend = Class.create( {
      */
   _generateElement: function(id, name, isObsolete) {
     var color = this.getObjectColor(id);
-    var obsoleteClass = isObsolete ? "obsolete " : "";
-    var item = new Element('li', {'class' : 'disorder '+obsoleteClass+'drop-'+this._getPrefix(), 'id' : this._getPrefix() + '-' + id}).update(new Element('span', {'class' : 'disorder-name'}).update(name));
+    var obsoleteClass = isObsolete ? 'obsolete ' : '';
+    var item = new Element('li', {'class' : 'disorder ' + obsoleteClass + 'drop-'+this._getPrefix(), 'id' : this._getPrefix() + '-' + id}).update(new Element('span', {'class' : 'disorder-name'}).update(name));
     var bubble = new Element('span', {'class' : 'disorder-color'});
-    var tooltiptext = new Element('span', {'class': 'tooltiptext'}).insert('This HPO term is obsolete. See the HPO terms tab for details.');
+    var tooltiptext = new Element('span', { class: 'tooltiptext' }).insert(
+      'This HPO term is obsolete. See the HPO terms tab for details.'
+    );
     bubble.style.backgroundColor = color;
     item.insert({'top' : bubble}).insert(tooltiptext);
     var countLabel = new Element('span', {'class' : 'disorder-cases'});

--- a/src/legend.js
+++ b/src/legend.js
@@ -93,13 +93,13 @@ export const Legend = Class.create( {
      * @param {String} Name The description of the object to be displayed
      * @param {Number} nodeID ID of the Person who has this object associated with it
      */
-  addCase: function(id, name, nodeID) {
+  addCase: function(id, name, nodeID, isObsolete = false) {
     if(Object.keys(this._affectedNodes).length == 0) {
       this._legendBox.show();
     }
     if(!this._hasAffectedNodes(id)) {
       this._affectedNodes[id] = [nodeID];
-      var listElement = this._generateElement(id, name);
+      var listElement = this._generateElement(id, name, isObsolete);
       this._list.insert(listElement);
     }
     else {
@@ -160,12 +160,14 @@ export const Legend = Class.create( {
      * @param {String} name The human-readable object name or description
      * @return {HTMLLIElement} List element to be insert in the legend
      */
-  _generateElement: function(id, name) {
+  _generateElement: function(id, name, isObsolete) {
     var color = this.getObjectColor(id);
-    var item = new Element('li', {'class' : 'disorder '+'drop-'+this._getPrefix(), 'id' : this._getPrefix() + '-' + id}).update(new Element('span', {'class' : 'disorder-name'}).update(name));
+    var obsoleteClass = isObsolete ? "obsolete " : "";
+    var item = new Element('li', {'class' : 'disorder '+obsoleteClass+'drop-'+this._getPrefix(), 'id' : this._getPrefix() + '-' + id}).update(new Element('span', {'class' : 'disorder-name'}).update(name));
     var bubble = new Element('span', {'class' : 'disorder-color'});
+    var tooltiptext = new Element('span', {'class': 'tooltiptext'}).insert('This HPO term is obsolete');
     bubble.style.backgroundColor = color;
-    item.insert({'top' : bubble});
+    item.insert({'top' : bubble}).insert(tooltiptext);
     var countLabel = new Element('span', {'class' : 'disorder-cases'});
     var countLabelContainer = new Element('span', {'class' : 'disorder-cases-container'}).insert('(').insert(countLabel).insert(')');
     item.insert(' ').insert(countLabelContainer);

--- a/src/legend.js
+++ b/src/legend.js
@@ -162,14 +162,17 @@ export const Legend = Class.create( {
      */
   _generateElement: function(id, name, isObsolete) {
     var color = this.getObjectColor(id);
-    var obsoleteClass = isObsolete ? 'obsolete ' : '';
-    var item = new Element('li', {'class' : 'disorder ' + obsoleteClass + 'drop-'+this._getPrefix(), 'id' : this._getPrefix() + '-' + id}).update(new Element('span', {'class' : 'disorder-name'}).update(name));
+    var obsoleteClass = isObsolete ? 'obsolete' : '';
+    var item = new Element('li', {'class' : 'disorder ' + obsoleteClass + ' drop-'+this._getPrefix(), 'id' : this._getPrefix() + '-' + id}).update(new Element('span', {'class' : 'disorder-name'}).update(name));
     var bubble = new Element('span', {'class' : 'disorder-color'});
     var tooltiptext = new Element('span', { class: 'tooltiptext' }).insert(
       'This HPO term is obsolete. See the HPO terms tab for details.'
     );
     bubble.style.backgroundColor = color;
-    item.insert({'top' : bubble}).insert(tooltiptext);
+    item.insert({'top' : bubble})
+    if (isObsolete) {
+      item.insert(tooltiptext);
+    }
     var countLabel = new Element('span', {'class' : 'disorder-cases'});
     var countLabelContainer = new Element('span', {'class' : 'disorder-cases-container'}).insert('(').insert(countLabel).insert(')');
     item.insert(' ').insert(countLabelContainer);

--- a/src/person.js
+++ b/src/person.js
@@ -814,7 +814,6 @@ export const Person = Class.create(AbstractPerson, {
       this.removeHPO( this.getHPO()[i] );
     }
     for(i = 0; i < hpos.length; i++) {
-      console.log("SET HPO: " + hpos[i])
       this.addHPO(hpos[i]);
     }
   },

--- a/src/person.js
+++ b/src/person.js
@@ -768,9 +768,15 @@ export const Person = Class.create(AbstractPerson, {
      * @param {HPOTerm} hpo HPOTerm object or a free-text name string
      */
   addHPO: function(hpo) {
+    // Support free-text string argument
     if (typeof hpo != 'object') {
       hpo = editor.getHPOLegend().getTerm(hpo);
     }
+    // Support object with name and isObsolete properties
+    if (hpo && hpo.name) {
+      hpo = editor.getHPOLegend().getTerm(hpo.name, hpo.isObsolete);
+    }
+
     if(!this.hasHPO(hpo.getID())) {
       editor.getHPOLegend().addCase(hpo.getID(), hpo.getName(), this.getID(), hpo.getObsolete());
       this.getHPO().push(hpo.getID());
@@ -808,7 +814,10 @@ export const Person = Class.create(AbstractPerson, {
       this.removeHPO( this.getHPO()[i] );
     }
     for(i = 0; i < hpos.length; i++) {
-      this.addHPO( hpos[i] );
+      console.log("SET HPO: " + hpos[i])
+      // TODO: Update this when API changes.
+      var obs = Math.random() > 0.5;
+      this.addHPO({name: hpos[i], isObsolete: obs});
     }
   },
 

--- a/src/person.js
+++ b/src/person.js
@@ -765,7 +765,7 @@ export const Person = Class.create(AbstractPerson, {
      * Adds HPO term to the list of this node's phenotypes and updates the Legend.
      *
      * @method addHPO
-     * @param {HPOTerm} hpo HPOTerm object or a free-text name string
+     * @param {HPOTerm} hpo HPOTerm object or a free-text name string or an object with name and isObsolete props
      */
   addHPO: function(hpo) {
     // Support free-text string argument
@@ -806,7 +806,7 @@ export const Person = Class.create(AbstractPerson, {
      * Sets the list of HPO temrs of this person to the given list
      *
      * @method setHPO
-     * @param {Array} hpos List of HPOTerm objects
+     * @param {Array} hpos List of HPO term objects {name: string, isObsolete: bool}
      */
   setHPO: function(hpos) {
     var i;
@@ -815,9 +815,7 @@ export const Person = Class.create(AbstractPerson, {
     }
     for(i = 0; i < hpos.length; i++) {
       console.log("SET HPO: " + hpos[i])
-      // TODO: Update this when API changes.
-      var obs = Math.random() > 0.5;
-      this.addHPO({name: hpos[i], isObsolete: obs});
+      this.addHPO(hpos[i]);
     }
   },
 

--- a/src/person.js
+++ b/src/person.js
@@ -772,7 +772,7 @@ export const Person = Class.create(AbstractPerson, {
       hpo = editor.getHPOLegend().getTerm(hpo);
     }
     if(!this.hasHPO(hpo.getID())) {
-      editor.getHPOLegend().addCase(hpo.getID(), hpo.getName(), this.getID());
+      editor.getHPOLegend().addCase(hpo.getID(), hpo.getName(), this.getID(), hpo.getObsolete());
       this.getHPO().push(hpo.getID());
     }
     else {


### PR DESCRIPTION
Extend the HPO Legend to receive additional property for when HPO terms are obsolete. API that provides this data is yet to be changed.
When obsolete, terms display a warning icon and hover-over tooltip to alert user.