### PR TITLE
SAP-19440: Add git diff to CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,4 +34,6 @@ jobs:
               exit 0;
             fi
 
+            echo "run npm build and commit the main.bundle.js";
+            git diff;
             exit 1;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
               exit 0;
             fi
 
-            echo "run npm build and commit the main.bundle.js";
+            echo -e "Your build failed as the latest changes were not included in the built JS files";
+            echo -e "To fix this, run npm build and commit the main.bundle.js changes";
             git diff;
             exit 1;


### PR DESCRIPTION
When working with panogram it is essential that the package is built and committed. If the developer doesn't do it a cryptic message was shown in CircleCI.

This PR adds a handy reminder message, and provides the `git diff` so that the dev can see what they need to do.

![panogram build](https://user-images.githubusercontent.com/49521787/106163146-c2646680-6180-11eb-9e11-fc33308251c1.png)
