### PR TITLE
SAP-19842: Allow numbers in HPO legend

### DIFF
--- a/main.bundle.js
+++ b/main.bundle.js
@@ -35352,7 +35352,6 @@ var Controller = exports.Controller = Class.create({
   },
 
   handleUndo: function handleUndo(event) {
-    console.log("handleUndo");
     console.log('event: ' + event.eventName + ', memo: ' + (0, _helpers.stringifyObject)(event.memo));
     editor.getActionStack().undo();
   },

--- a/main.bundle.js
+++ b/main.bundle.js
@@ -16775,7 +16775,7 @@ HPOTerm.sanitizeID = function (id) {
   temp = temp.replace(/\,/g, '__COMMA__');
   // XRegExp handles unicode characters for us, so languages like chinese don't
   // get filtered out here.
-  return temp.replace((0, _xregexp2.default)('[^\\pL\\p{Dash_Punctuation}*,;_\\-*]', 'g'), '__');
+  return temp.replace((0, _xregexp2.default)('[^\\p{L}\\p{N}\\p{Dash_Punctuation}*,;_\\-*]', 'g'), '__');
 };
 
 HPOTerm.desanitizeID = function (id) {
@@ -35352,6 +35352,7 @@ var Controller = exports.Controller = Class.create({
   },
 
   handleUndo: function handleUndo(event) {
+    console.log("handleUndo");
     console.log('event: ' + event.eventName + ', memo: ' + (0, _helpers.stringifyObject)(event.memo));
     editor.getActionStack().undo();
   },

--- a/main.bundle.js
+++ b/main.bundle.js
@@ -16775,6 +16775,7 @@ HPOTerm.sanitizeID = function (id) {
   temp = temp.replace(/\,/g, '__COMMA__');
   // XRegExp handles unicode characters for us, so languages like chinese don't
   // get filtered out here.
+  // We explicitly allow numbers in the legends due to bug SAP-19842
   return temp.replace((0, _xregexp2.default)('[^\\p{L}\\p{N}\\p{Dash_Punctuation}*,;_\\-*]', 'g'), '__');
 };
 

--- a/src/controller.js
+++ b/src/controller.js
@@ -31,6 +31,7 @@ export const Controller = Class.create({
 
   handleUndo: function(event)
     {
+    console.log('handleUndo');
     console.log('event: ' + event.eventName + ', memo: ' + stringifyObject(event.memo));
     editor.getActionStack().undo();
   },

--- a/src/controller.js
+++ b/src/controller.js
@@ -31,7 +31,6 @@ export const Controller = Class.create({
 
   handleUndo: function(event)
     {
-    console.log("handleUndo");
     console.log('event: ' + event.eventName + ', memo: ' + stringifyObject(event.memo));
     editor.getActionStack().undo();
   },

--- a/src/controller.js
+++ b/src/controller.js
@@ -31,7 +31,7 @@ export const Controller = Class.create({
 
   handleUndo: function(event)
     {
-    console.log('handleUndo');
+    console.log("handleUndo");
     console.log('event: ' + event.eventName + ', memo: ' + stringifyObject(event.memo));
     editor.getActionStack().undo();
   },

--- a/src/hpoTerm.js
+++ b/src/hpoTerm.js
@@ -82,6 +82,7 @@ HPOTerm.sanitizeID = function(id) {
   temp = temp.replace(/\,/g, '__COMMA__');
   // XRegExp handles unicode characters for us, so languages like chinese don't
   // get filtered out here.
+  // We explicitly allow numbers in the legends due to bug SAP-19842
   return temp.replace(XRegExp('[^\\p{L}\\p{N}\\p{Dash_Punctuation}*,;_\\-*]', 'g'),  '__');
 };
 

--- a/src/hpoTerm.js
+++ b/src/hpoTerm.js
@@ -1,4 +1,4 @@
-import XRegExp from 'xregexp'
+import XRegExp from 'xregexp';
 
 /*
  * HPOTerm is a class for storing phenotype information and loading it from the
@@ -82,7 +82,7 @@ HPOTerm.sanitizeID = function(id) {
   temp = temp.replace(/\,/g, '__COMMA__');
   // XRegExp handles unicode characters for us, so languages like chinese don't
   // get filtered out here.
-  return temp.replace(XRegExp('[^\\pL\\p{Dash_Punctuation}*,;_\\-*]', 'g'),  '__');
+  return temp.replace(XRegExp('[^\\p{L}\\p{N}\\p{Dash_Punctuation}*,;_\\-*]', 'g'),  '__');
 };
 
 HPOTerm.desanitizeID = function(id) {


### PR DESCRIPTION
Bug ticket: [SAP-19842](https://jira.congenica.net/browse/SAP-19842)

One of our customisations to the panogram code was to sanitize the HPO legend IDs to handle unicode chars. The regex used stripped numbers from the IDs, only allowing letter type characters. This PR allows number characters too, which fixes the labels.

![SAP-19842](https://user-images.githubusercontent.com/49521787/107624539-f6e12380-6c52-11eb-83aa-53d939eca564.png)
