### PR TITLE
SAP-27182: changes executor to use next-gen image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ jobs:
           name: Install dependencies
           command: |
             sudo chown -R 3434:3434 "/home/circleci/.npm"
+            sudo chown -R 3434:3434 "/home/circleci/.config"
+            sudo chown -R 3434:3434 "/home/circleci/.cache"
             npm ci
             bower install
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:carbon
+      - image: cimg/node:8.17
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: v1-dependency-cache-{{ checksum "package.json" }}
       - run:
           name: Install Bower
           command: sudo npm install -g bower
@@ -16,7 +16,7 @@ jobs:
             npm ci
             bower install
       - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: v1-dependency-cache-{{ checksum "package.json" }}
           paths:
             - ./node_modules
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            sudo chown -R 3434:3434 "/home/circleci/.npm"
             npm ci
             bower install
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ jobs:
           command: |
             sudo chown -R 3434:3434 "/home/circleci/.npm"
             sudo chown -R 3434:3434 "/home/circleci/.config"
-            sudo chown -R 3434:3434 "/home/circleci/.cache"
             npm ci
             bower install
       - save_cache:


### PR DESCRIPTION
https://jira.congenica.net/browse/SAP-27182

Quoting CircleCI email they sent out recently

>On Tuesday, March 15, 2022, GitHub will be changing which keys are supported in SSH and removing unencrypted Git protocol. Please reference the [blog post](https://go.circleci.com/NDg1LVpNSC02MjYAAAGCo4Yptp4MdfmfnxBPE_qHSTuwqTPJlgV8w9VD5AviZDKBJmGWDbFRi_7nieeRQaSzFf5eqZQ=) GitHub released regarding this change.

Because legacy images are no longer updated since 31 December 2021, they won't get the necessary update to continue to work with github.